### PR TITLE
PRED-2717 Fixed Pagination box spacing issue in IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ When Making changes, follow these steps
 
 ## Changelog
 
+### 1.0.17
+- Fixed Pagination box spacing issue for IE11.
+
 ### 1.0.16
 - Performance improvements for apps using `conf.client.head.addlPathedScripts`
 

--- a/lib/src/scss/_pager-buttons.scss
+++ b/lib/src/scss/_pager-buttons.scss
@@ -74,6 +74,7 @@ $pager-button-border-width: 1px !default;
   input {
     display: inline;
     width: auto;
+    max-width: 67px;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iui-table",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Angular dynamic table directive",
   "main": "./lib/index.js",
   "private": false,


### PR DESCRIPTION
@mcastre  PRED-2717 : IE11 - Pagination box spacing is more in past list page